### PR TITLE
Remove AST

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,17 +23,7 @@ export default function image ( options = {} ) {
 			if ( !mime ) return null; // not an image
 
 			const data = readFileSync( id, 'base64' );
-			const code = `var img = new Image(); img.src = 'data:${mime};base64,${data}'; export default img;`;
-
-			const ast = {
-				type: 'Program',
-				sourceType: 'module',
-				start: 0,
-				end: null,
-				body: []
-			};
-
-			return { ast, code, map: { mappings: '' } };
+			return `var img = new Image(); img.src = 'data:${mime};base64,${data}'; export default img;`;
 		}
 	};
 }


### PR DESCRIPTION
I ran into #2 and it reminded me of a similar issue I had with one of my own plugins. For whatever reason, adding an AST seems to confuse Rollup. This patch makes the plugin only return code rather than an object, because a source map is useless in this case anyway.